### PR TITLE
Remove use of dep and update version of Go to Go 1.13

### DIFF
--- a/container/dependencies.sh
+++ b/container/dependencies.sh
@@ -11,4 +11,3 @@ mv go /usr/local
 
 mkdir -p /.gopath/bin
 mkdir -p /.gopath/src
-curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh

--- a/container/dependencies.sh
+++ b/container/dependencies.sh
@@ -5,8 +5,8 @@ apt-get install -y git mercurial gcc curl postgresql openssl
 
 wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
 
-wget -nv https://storage.googleapis.com/golang/go1.10.linux-amd64.tar.gz
-tar xf go1.10.linux-amd64.tar.gz
+wget -nv https://dl.google.com/go/go1.13.linux-amd64.tar.gz
+tar xf go1.13.linux-amd64.tar.gz
 mv go /usr/local
 
 mkdir -p /.gopath/bin

--- a/container/start.sh
+++ b/container/start.sh
@@ -19,7 +19,6 @@ function download_bridge() {
     mkdir -p $MONOREPO
     git clone https://github.com/stellar/go $MONOREPO
     cd $MONOREPO
-    dep ensure -v
     go build -v ./services/bridge
     go build -v ./services/compliance
     cd -
@@ -34,7 +33,6 @@ function download_bridge() {
     cd $MONOREPO
     git checkout release-bridge-$RC_VERSION
     git pull
-    dep ensure -v
     go build -v ./services/bridge
     cd -
     # Move binaries to home dir
@@ -44,7 +42,6 @@ function download_bridge() {
     cd $MONOREPO
     git checkout release-compliance-$RC_VERSION
     git pull
-    dep ensure -v
     go build -v ./services/compliance
     cd -
     # Move binaries to home dir


### PR DESCRIPTION
### Summary

Remove use of `dep` and update version of Go to Go 1.13.

### Goal and scope

The `stellar/go` repo was changed in stellar/go#1542 to use the build-in Go Modules instead of Dep for dependency management. The standard `go` commands can now be relied on for downloading and installing dependencies without any need to run any additional commands like we had to with Dep. Go 1.13 is the latest version of Go and we should use it for these tests since the repository no longer supports Go 1.10.

Close #6

### Summary of changes

- Update Go version to 1.13
- Remove use of Dep

### Known limitations & issues

N/A

### What shouldn't be reviewed

N/A